### PR TITLE
Prep 1.4.1

### DIFF
--- a/.github/workflows/integration-cleanup.yml
+++ b/.github/workflows/integration-cleanup.yml
@@ -1,0 +1,34 @@
+name: Integration Cleanup
+on:
+  # Run Integration Cleanup once per day (at 05:00 UTC)
+  schedule:
+    - cron: '0 5 * * *'
+env:
+  NAMESPACE: equinix
+  COLLECTION_NAME: metal
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    name: Integration Cleanup
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          # it is just required to run that once as "ansible-test integration" in the docker image
+          # will run on all python versions it supports.
+          python-version: 3.8
+
+      - name: Install ansible-base
+        run: pip install https://github.com/ansible/ansible/archive/stable-2.10.tar.gz --disable-pip-version-check
+
+      - name: Run cleanup
+        env:
+          METAL_API_TOKEN: ${{ secrets.METAL_API_TOKEN }}
+        run: |
+          ansible-playbook cleanup.yaml
+        working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,15 @@ Equinix.Metal Release Notes
 .. contents:: Topics
 
 
+v1.4.1
+======
+
+Bugfixes
+--------
+
+- project - fix deletion when there are more than 10 projects
+- project_info - fix listing when there are more than 10 projects
+
 v1.4.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This collection depends on [packet-python](https://github.com/packethost/packet-
 ### Inventory plugins
 Name | Description
 --- | ---
-[equinix.metal.device](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.device.py_inventory.rst)|Equinix Metal Device inventory source
+[equinix.metal.device](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.device_inventory.rst)|Equinix Metal Device inventory source
 
 ### Modules
 Name | Description

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -86,4 +86,4 @@ plugins:
   shell: {}
   strategy: {}
   vars: {}
-version: 1.4.0
+version: 1.4.1

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -75,3 +75,11 @@ releases:
       name: user_info
       namespace: ''
     release_date: '2021-03-05'
+  1.4.1:
+    changes:
+      bugfixes:
+      - project - fix deletion when there are more than 10 projects
+      - project_info - fix listing when there are more than 10 projects
+    fragments:
+    - 20-increase-project-pagesize.yml
+    release_date: '2021-03-09'

--- a/cleanup.yaml
+++ b/cleanup.yaml
@@ -1,0 +1,39 @@
+---
+- hosts: localhost
+  vars:
+    test_prefix: ansible-integration-test
+  tasks:
+    - name: list projects
+      equinix.metal.project_info:
+      register: test_projects
+
+    - set_fact:
+        matching_projects: "{{ test_projects.projects | selectattr('name', 'match', '^'+test_prefix) | list }}"
+
+    - name: list devices
+      equinix.metal.device_info:
+        project_id: "{{ item.id }}"
+      register: test_devices
+      loop: "{{ matching_projects }}"
+
+    - set_fact:
+        mp: "{{ test_devices.results | map(attribute='item.id') | list }}"
+        md: "{{ test_devices.results | map(attribute='devices') | map('selectattr', 'hostname', 'match', '^'+test_prefix) | map('map', attribute='id') | list }}"
+
+    - set_fact:
+        matching_proj_device_ids: "{{ dict(mp | zip(md)) | dict2items(key_name='project_id', value_name='device_ids') | selectattr('device_ids') | list }}"
+
+    - name: delete test devices
+      equinix.metal.device:
+        device_ids: "{{ item.device_ids }}"
+        project_id: "{{ item.project_id }}"
+        state: absent
+      loop: "{{ matching_proj_device_ids }}"
+      ignore_errors: true
+
+    - name: delete test projects
+      equinix.metal.project:
+        id: "{{ item.id }}"
+        state: absent
+      loop: "{{ matching_projects }}"
+      ignore_errors: true

--- a/docs/equinix.metal.device_inventory.rst
+++ b/docs/equinix.metal.device_inventory.rst
@@ -1,9 +1,9 @@
-.. _equinix.metal.device.py_inventory:
+.. _equinix.metal.device_inventory:
 
 
-***********************
-equinix.metal.device.py
-***********************
+********************
+equinix.metal.device
+********************
 
 **Equinix Metal Device inventory source**
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -56,3 +56,4 @@ build_ignore:
   - '.gitignore'
   - 'changelogs/.plugin-cache.yaml'
   - 'tests/integration/integration_config.yml'
+  - 'cleanup.yaml'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: equinix
 name: metal
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.4.0
+version: 1.4.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/inventory/device.py
+++ b/plugins/inventory/device.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = '''
-    name: device.py
+    name: device
     plugin_type: inventory
     short_description: Equinix Metal Device inventory source
     requirements:

--- a/plugins/modules/project.py
+++ b/plugins/modules/project.py
@@ -122,10 +122,10 @@ def act_on_project(target_state, module):
     given_name = module.params.get('name')
     if given_id:
         matching_projects = [
-            p for p in module.metal_conn.list_projects() if given_id == p.id]
+            p for p in module.metal_conn.list_projects(params={'per_page': 1000, 'exclude': 'members'}) if given_id == p.id]
     else:
         matching_projects = [
-            p for p in module.metal_conn.list_projects() if given_name == p.name]
+            p for p in module.metal_conn.list_projects(params={'per_page': 1000, 'exclude': 'members'}) if given_name == p.name]
 
     if target_state == 'present':
         if len(matching_projects) == 0:

--- a/plugins/modules/project_info.py
+++ b/plugins/modules/project_info.py
@@ -69,7 +69,7 @@ from ansible_collections.equinix.metal.plugins.module_utils.metal import Ansible
 
 
 def get_project_info(module):
-    projects = module.metal_conn.list_projects()
+    projects = module.metal_conn.list_projects(params={'per_page': 1000, 'exclude': 'members'})
 
     if module.params.get('ids'):
         projects = [p for p in projects if p.id in module.params.get('ids')]


### PR DESCRIPTION
- Bugfix for listing/deleting projects when there are more than 10 projects
- Periodic cleanup job for integration tests
- Followup cleanup for fixing the name of the inventory plugin in documentation
- rev version to 1.4.1