### PR TITLE
python-packet should be packet-python

### DIFF
--- a/plugins/module_utils/metal.py
+++ b/plugins/module_utils/metal.py
@@ -70,7 +70,7 @@ class AnsibleMetalModule(object):
         self._name = self._module._name
 
         if not HAS_METAL_SDK:
-            self.fail_json(msg='python-packet required for this module')
+            self.fail_json(msg='packet-python required for this module')
 
         if local_settings["default_args"]:
             self.metal_conn = packet.Manager(auth_token=self.params.get('api_token'))

--- a/plugins/modules/device.py
+++ b/plugins/modules/device.py
@@ -484,7 +484,7 @@ def main():
     )
 
     if not HAS_METAL_SDK:
-        module.fail_json(msg='python-packet required for this module')
+        module.fail_json(msg='packet-python required for this module')
 
     state = module.params.get('state')
 

--- a/plugins/modules/project.py
+++ b/plugins/modules/project.py
@@ -192,7 +192,7 @@ def main():
         ]
     )
     if not HAS_METAL_SDK:
-        module.fail_json(msg='python-packet required for this module')
+        module.fail_json(msg='packet-python required for this module')
 
     state = module.params.get('state')
 


### PR DESCRIPTION
The pip package to install is `packet-python` so it looks like these are flipped in the error messages. 