### PR TITLE
fix Ansible documentation linter violations

### DIFF
--- a/plugins/modules/capacity_info.py
+++ b/plugins/modules/capacity_info.py
@@ -39,7 +39,7 @@ EXAMPLES = '''
 
 RETURN = '''
 capacity:
-    description: Information about capacity that was found
+    description: Information about capacity that was found.
     type: dict
     sample: '{
                 "da11": {

--- a/plugins/modules/device.py
+++ b/plugins/modules/device.py
@@ -91,7 +91,7 @@ options:
         type: str
     user_data:
         description:
-            - Userdata blob made available to the machine
+            - Userdata blob made available to the machine.
         type: str
     wait_for_public_IPv:
         description:

--- a/plugins/modules/ip_subnet.py
+++ b/plugins/modules/ip_subnet.py
@@ -14,7 +14,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ip_subnet
-short_description: Assign IP subnet to a bare metal server.
+short_description: Assign IP subnet to a bare metal server
 description:
     - Assign or unassign IPv4 or IPv6 subnets to or from a device in Equinix Metal.
     - IPv4 subnets must come from already reserved block.


### PR DESCRIPTION
Part of #26

~I don't know how to generate the linting output that was quoted in the original post. Ideally we will bake that linter into our CI.~ _see https://github.com/equinix/ansible-collection-metal/pull/33#issuecomment-825393648_

* [ ] return device_id: no sample (check everywhere) (#53 ?)
* [x] short_description: line 1 ends with a dot (must not)
* [x] return capacity: line 1 does not end with a dot (in return sections lines must end with a dot)
* [ ] no "notes" section, it should, at least, contain info about check_mode support, please put something like:
  > notes:
  > - Supports / Does not support C(check_mode).
* [x] opt user_data: line 1 does not end with a dot (pleas recheck all the options end with a dot).